### PR TITLE
Typo mm directory name.

### DIFF
--- a/README.html
+++ b/README.html
@@ -315,7 +315,7 @@
     </li>
 
     <li>
-        <label for="menu-5">[week 065] init/main.c::start_kernel() → /mm/page_alloc.c::build_all_zonelists()</label>
+        <label for="menu-5">[week 065] init/main.c::start_kernel() → mm/page_alloc.c::build_all_zonelists()</label>
         <input type="checkbox" id="menu-5" />
         <ol>
             <li class="file">


### PR DESCRIPTION
Typo /mm/.. directory name.
Fix mm/..